### PR TITLE
Fix token parsing from Authorization header

### DIFF
--- a/aschatapp/fastapiapp/routers/chat.py
+++ b/aschatapp/fastapiapp/routers/chat.py
@@ -42,7 +42,10 @@ async def websocket_endpoint(websocket: WebSocket, chat_id: str):
     logging.info(f"Received WebSocket connection request for chat {chat_id} from {websocket.client.host}")
 
     token = websocket.headers.get("Authorization")
-    if not token:
+    if token:
+        if token.lower().startswith("bearer "):
+            token = token.split(" ", 1)[1]
+    else:
         token = websocket.query_params.get("token")
         if not token:
             logging.error("No Authorization token provided in headers or query params")


### PR DESCRIPTION
## Summary
- handle `Authorization` header in websocket endpoint

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684054af1f388328af66fe469da6924d