### PR TITLE
Add health endpoint

### DIFF
--- a/aschatapp/fastapiapp/app.py
+++ b/aschatapp/fastapiapp/app.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
-from .routers import chat
+from .routers import chat, health
 
 
 app = FastAPI()
 
 app.include_router(chat.router)
+app.include_router(health.router)

--- a/aschatapp/fastapiapp/routers/health.py
+++ b/aschatapp/fastapiapp/routers/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/health")
+async def health_check():
+    """Simple health check endpoint."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a simple `/health` endpoint for FastAPI
- register the new health router

## Testing
- `python -m compileall -q aschatapp/fastapiapp`

------
https://chatgpt.com/codex/tasks/task_e_6840601524c08328b276238e2a73ff88