### PR TITLE
Optimize websocket connections and messaging

### DIFF
--- a/aschatapp/chats/views.py
+++ b/aschatapp/chats/views.py
@@ -61,7 +61,15 @@ class ChatViewSet(viewsets.ModelViewSet):
             raise PermissionDenied("You are not a member of this chat.")
 
         chat_serializer = self.get_serializer(chat)
-        messages = Message.objects.filter(chat=chat).order_by("created_at")
+
+        limit = int(request.query_params.get("limit", 50))
+        offset = int(request.query_params.get("offset", 0))
+
+        messages = (
+            Message.objects.filter(chat=chat)
+            .order_by("created_at")
+            [offset : offset + limit]
+        )
         message_serializer = MessageSerializer(
             messages,
             many=True,

--- a/aschatapp/fastapiapp/config.py
+++ b/aschatapp/fastapiapp/config.py
@@ -8,5 +8,14 @@ env = environ.Env()
 
 environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
-CELERY_USERNAME = env.str("CELERY_USERNAME")
-CELERY_PASSWORD = env.str("CELERY_PASSWORD")
+CELERY_USERNAME = env.str("CELERY_USERNAME", default="guest")
+CELERY_PASSWORD = env.str("CELERY_PASSWORD", default="guest")
+
+SECRET_KEY = env.str("SECRET_KEY", default="change")
+
+# External service URLs
+DJANGO_API_URL = env.str("DJANGO_API_URL", default="http://django:8000/api/")
+RABBITMQ_URL = env.str(
+    "RABBITMQ_URL",
+    default=f"amqp://{CELERY_USERNAME}:{CELERY_PASSWORD}@rabbitmq/",
+)

--- a/aschatapp/fastapiapp/routers/chat.py
+++ b/aschatapp/fastapiapp/routers/chat.py
@@ -1,16 +1,16 @@
-import logging
-
 import httpx
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.security import OAuth2PasswordBearer
 
-from ..utils.auth import get_user_from_django
+from ..config import DJANGO_API_URL
+from ..utils.auth import get_user_from_token
 from ..utils.websocket import manage_websocket
+from ..utils.logging_config import get_logger
 
 
 router = APIRouter()
 
-django_api_url = "http://django:8000/api/"
+logger = get_logger(__name__)
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/token")
 
@@ -18,7 +18,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/token")
 @router.get("/chats")
 async def get_chats():
     async with httpx.AsyncClient() as client:
-        response = await client.get(f"{django_api_url}chats/")
+        response = await client.get(f"{DJANGO_API_URL}chats/")
 
     if response.status_code == 200:
         return response.json()
@@ -29,7 +29,7 @@ async def get_chats():
 @router.get("/chats/{chat_id}")
 async def get_chat(chat_id: str):
     async with httpx.AsyncClient() as client:
-        response = await client.get(f"{django_api_url}chats/{chat_id}/")
+        response = await client.get(f"{DJANGO_API_URL}chats/{chat_id}/")
 
     if response.status_code == 200:
         return response.json()
@@ -39,24 +39,32 @@ async def get_chat(chat_id: str):
 
 @router.websocket("/ws/chat/{chat_id}")
 async def websocket_endpoint(websocket: WebSocket, chat_id: str):
-    logging.info(f"Received WebSocket connection request for chat {chat_id} from {websocket.client.host}")
+    logger.info(
+        f"Received WebSocket connection request for chat {chat_id} from {websocket.client.host}"
+    )
 
     token = websocket.headers.get("Authorization")
     if not token:
         token = websocket.query_params.get("token")
         if not token:
-            logging.error("No Authorization token provided in headers or query params")
+            logger.error("No Authorization token provided in headers or query params")
             await websocket.send_text("Error: No token provided")
             await websocket.close(code=4000)
             return
 
     try:
-        user_data = await get_user_from_django(token)
-        logging.info(f"User authenticated, user_id: {user_data['id']}")
-        await manage_websocket(websocket, chat_id, user_id=user_data['id'], username=user_data['username'], token=token)
+        user_data = await get_user_from_token(token)
+        logger.info(f"User authenticated, user_id: {user_data['id']}")
+        await manage_websocket(
+            websocket,
+            chat_id,
+            user_id=user_data["id"],
+            username=user_data.get("username", ""),
+            token=token,
+        )
     except WebSocketDisconnect:
-        logging.info(f"Client disconnected from chat {chat_id}")
-        logging.info(f"Client data: {token}")
+        logger.info(f"Client disconnected from chat {chat_id}")
+        logger.info(f"Client data: {token}")
     except HTTPException as e:
-        logging.error(f"Authentication error: {e.detail}")
+        logger.error(f"Authentication error: {e.detail}")
         await websocket.close(code=4000)

--- a/aschatapp/fastapiapp/utils/auth.py
+++ b/aschatapp/fastapiapp/utils/auth.py
@@ -1,39 +1,31 @@
-import logging
-import httpx
+import jwt
 from fastapi import HTTPException
 
+from ..config import SECRET_KEY
+from .logging_config import get_logger
 
-async def get_user_from_django(token: str):
+logger = get_logger(__name__)
+
+
+async def get_user_from_token(token: str) -> dict:
+    """Decode JWT token locally and return user information."""
     credentials_exception = HTTPException(
         status_code=401,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    logging.info(f"Decoding token...")
+    logger.info("Decoding token...")
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "http://django:8000/api/user/",
-                headers={"Authorization": f"Bearer {token}"}
-            )
-
-        logging.info(f"Received response from Django. Status code: {response.status_code}")
-
-        if response.status_code != 200:
-            logging.error(f"Failed to retrieve user data. Status code: {response.status_code}, Response: {response.text}")
-            raise HTTPException(status_code=401, detail="User not found in Django system")
-
-        user_data = response.json()
-
-        logging.info(f"User data retrieved: {user_data}")
-
+        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+        user_id = payload.get("user_id") or payload.get("id")
+        if not user_id:
+            raise credentials_exception
+        username = payload.get("username")
+        user_data = {"id": user_id, "username": username}
+        logger.info(f"Token decoded, user_id: {user_id}")
         return user_data
-
-    except httpx.HTTPStatusError as e:
-        logging.error(f"HTTP error occurred: {str(e)}")
-        raise credentials_exception
-    except Exception as e:
-        logging.error(f"Unexpected error occurred: {str(e)}")
+    except jwt.PyJWTError as exc:
+        logger.error(f"JWT decode failed: {exc}")
         raise credentials_exception

--- a/aschatapp/fastapiapp/utils/logging_config.py
+++ b/aschatapp/fastapiapp/utils/logging_config.py
@@ -1,0 +1,7 @@
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)

--- a/aschatapp/fastapiapp/utils/producers.py
+++ b/aschatapp/fastapiapp/utils/producers.py
@@ -1,32 +1,49 @@
 import aio_pika
 import json
-import logging
 from datetime import datetime
-from ..config import CELERY_PASSWORD, CELERY_USERNAME
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+from ..config import RABBITMQ_URL
+from .logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_connection = None
+_channel = None
+_queue = None
 
 
-async def send_message_to_rabbitmq(chat_id: str, user_id: int, content: str, image_data: str = None, audio_data: str = None):
+async def _get_channel():
+    """Get or create a RabbitMQ channel and queue."""
+    global _connection, _channel, _queue
+    if _connection is None or _connection.is_closed:
+        _connection = await aio_pika.connect_robust(RABBITMQ_URL)
+        _channel = await _connection.channel()
+        _queue = await _channel.declare_queue("messages_queue", durable=True)
+    return _channel, _queue
 
-    connection = await aio_pika.connect_robust(f"amqp://{CELERY_USERNAME}:{CELERY_PASSWORD}@rabbitmq/")
-    async with connection:
-        channel = await connection.channel()
 
-        queue = await channel.declare_queue('messages_queue', durable=True)
+async def send_message_to_rabbitmq(
+    chat_id: str,
+    user_id: int,
+    content: str,
+    image_data: str | None = None,
+    audio_data: str | None = None,
+):
+    """Publish a message to RabbitMQ using a persistent connection."""
 
-        message_data = {
-            "chat_id": chat_id,
-            "user_id": user_id,
-            "content": content,
-            "timestamp": datetime.utcnow().isoformat(),
-            "image_data": image_data,
-            "audio_data": audio_data
-        }
+    channel, queue = await _get_channel()
 
-        await channel.default_exchange.publish(
-            aio_pika.Message(body=json.dumps(message_data).encode()),
-            routing_key=queue.name
-        )
-        logger.info(f"Message sent to RabbitMQ: {message_data}")
+    message_data = {
+        "chat_id": chat_id,
+        "user_id": user_id,
+        "content": content,
+        "timestamp": datetime.utcnow().isoformat(),
+        "image_data": image_data,
+        "audio_data": audio_data,
+    }
+
+    await channel.default_exchange.publish(
+        aio_pika.Message(body=json.dumps(message_data).encode()),
+        routing_key=queue.name,
+    )
+    logger.info(f"Message sent to RabbitMQ: {message_data}")

--- a/aschatapp/fastapiapp/utils/websocket.py
+++ b/aschatapp/fastapiapp/utils/websocket.py
@@ -1,12 +1,13 @@
-import logging
 import httpx
 import json
 from fastapi import WebSocket, WebSocketDisconnect, HTTPException
 from datetime import datetime
-from .producers import send_message_to_rabbitmq
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+from ..config import DJANGO_API_URL
+from .producers import send_message_to_rabbitmq
+from .logging_config import get_logger
+
+logger = get_logger(__name__)
 
 active_connections = {}
 
@@ -15,8 +16,14 @@ def format_time(timestamp: str) -> str:
     return datetime.fromisoformat(timestamp).strftime('%Y-%m-%d %H:%M:%S')
 
 
-async def get_chat_details(client: httpx.AsyncClient, chat_id: str, auth_headers: dict):
-    response = await client.get(f"http://django:8000/api/chats/{chat_id}/details/", headers=auth_headers)
+async def get_chat_details(
+    client: httpx.AsyncClient, chat_id: str, auth_headers: dict
+):
+    """Fetch chat details from the Django service."""
+    response = await client.get(
+        f"{DJANGO_API_URL}chats/{chat_id}/details/",
+        headers=auth_headers,
+    )
     return response
 
 
@@ -76,24 +83,11 @@ async def manage_websocket(websocket: WebSocket, chat_id: str, user_id: int, use
             try:
                 while True:
                     data = await websocket.receive_json()
-                    message = data.get('message', '')
-                    image_data = data.get('image', None)
-                    audio_data = data.get('audio', None)
-                    
+                    message = data.get("message", "")
+                    image_data = data.get("image")
+                    audio_data = data.get("audio")
+
                     logger.info(f"Message received in chat {chat_id}: {message}")
-
-                    async with httpx.AsyncClient() as client:
-                        response = await get_chat_details(client, chat_id, auth_headers)
-
-                    if response.status_code != 200:
-                        logger.warning(f"User {user_id} is no longer a member of chat {chat_id}. Disconnecting.")
-
-                        if websocket in active_connections[chat_id]:
-                            active_connections[chat_id].remove(websocket)
-
-                        await websocket.send_text("You are no longer a member of this chat.")
-                        await websocket.close()
-                        return
 
                     await send_message_to_rabbitmq(chat_id, user_id, message, image_data, audio_data)
 


### PR DESCRIPTION
## Summary
- load config from environment including Django and RabbitMQ URLs
- centralize logging utility
- reuse a single RabbitMQ connection
- avoid repeated membership checks in websocket handler
- decode JWT locally instead of using HTTP
- make chat history endpoint paginated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684060fdb36c8328b3f89dac3d853e9c